### PR TITLE
update for OMV >=3.0.15

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+openmediavault-teamspeak3 (3.4) unstable; urgency=medium
+
+  * Changed dep to OMV = 3.0.15 to ensure compatibility
+  * Ported to > 3.0.15 w/ adding datamodels
+  * FIXME: ts3ui not working
+
+ -- OpenMediaVault Plugin Developers <user1@localhost.localdomain>  Fri, 18 Feb 2017 17:39:02 +0100
+
 openmediavault-teamspeak3 (3.3) stable; urgency=low
 
   * Changed dependency of OMV Package to = 3.0.13 to avoid accidental

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,14 @@ Source: openmediavault-teamspeak3
 Section: net
 Priority: optional
 Maintainer: OpenMediaVault Plugin Developers <plugins@omv-extras.org>
-Build-Depends: debhelper (>= 9)
+Build-Depends: debhelper (>= 9.0.0)
 Standards-Version: 3.9.6
 XB-Plugin-Section: gaming
+Homepage: http://omvextras.org/
 
 Package: openmediavault-teamspeak3
 Architecture: all
-Depends: openmediavault (= 3.0.13),
+Depends: openmediavault (>= 3.0.15),
          telnet,
          rsync,
          curl,

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://dep.debian.net/deps/dep5
 Upstream-Contact: OpenMediaVault Plugin Developers <plugins@omv-extras.org>
 Source: https://github.com/OpenMediaVault-Plugin-Developers/openmediavault-teamspeak3
-Copyright: 2013 OpenMediaVault Plugin Developers <plugins@omv-extras.org>
+Copyright: 2013-2017 OpenMediaVault Plugin Developers <plugins@omv-extras.org>
 License: GPL-3+
 
 Files: /var/www/openmediavault/images/teamspeak3.png

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,4 +1,22 @@
 #!/bin/sh
+# @license http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author Volker Theile <volker.theile@openmediavault.org>
+# @author OpenMediaVault Plugin Developers <plugins@omvextras.org>
+# @copyright Copyright (c) 2009-2013 Volker Theile
+# @copyright Copyright (c) 2013-2017 OpenMediaVault Plugin Developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 set -e
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,5 +1,23 @@
 #!/bin/sh
+# @license http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author Volker Theile <volker.theile@openmediavault.org>
+# @author OpenMediaVault Plugin Developers <plugins@omvextras.org>
+# @copyright Copyright (c) 2009-2013 Volker Theile
+# @copyright Copyright (c) 2013-2017 OpenMediaVault Plugin Developers
 #
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 set -e
 
 . /etc/default/openmediavault
@@ -17,7 +35,7 @@ case "$1" in
             fi
         fi
 
-        omv_config_delete "//services/teamspeak3"
+        omv_config_delete "/config/services/teamspeak3"
 
         if [ -d "/opt/teamspeak3" ]; then
             rm -rf /opt/teamspeak3 &>/dev/null

--- a/debian/triggers
+++ b/debian/triggers
@@ -1,2 +1,1 @@
 activate restart-engined
-

--- a/usr/share/openmediavault/datamodels/conf.service.teamspeak3.json
+++ b/usr/share/openmediavault/datamodels/conf.service.teamspeak3.json
@@ -1,0 +1,60 @@
+{
+	"type": "config",
+	"id": "conf.service.teamspeak3",
+	"title": "TeamSpeak 3",
+	"queryinfo": {
+		"xpath": "/config/services/teamspeak3",
+		"iterable": false
+	},
+	"properties": {
+		"enable": {
+			"type": "boolean",
+			"default": 0
+		},
+		"enablewi": {
+			"type": "boolean",
+			"default": 0
+		},
+		"password": {
+			"type": "string"
+		},
+		"vsport": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 65535,
+			"default": 9987
+		},
+		"queryport": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 65535,
+			"default": 10011
+		},
+		"fileport": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 65535,
+			"default": 30033
+		},
+		"showtab": {
+			"type": "boolean",
+			"default": 0
+		},
+		"languagewi": {
+			"type": "string",
+			"default": "en"
+		},
+		"eula": {
+			"type": "boolean",
+			"default": 0
+		},
+		"update": {
+			"type": "boolean",
+			"default": 0
+		},
+		"restartmsg": {
+			"type": "string"
+		}
+	}
+}
+

--- a/usr/share/openmediavault/datamodels/rpc.teamspeak3.json
+++ b/usr/share/openmediavault/datamodels/rpc.teamspeak3.json
@@ -1,0 +1,60 @@
+[{
+	"type": "rpc",
+	"id": "rpc.teamspeak3.setsettings",
+	"params": {
+		"type": "object",
+		"properties": {
+		    "enable": {
+		        "type": "boolean",
+		        "required": true
+		    },
+			"enablewi": {
+				"type": "boolean",
+		        "required": true
+			},
+			"password": {
+				"type": "string",
+		        "required": true
+			},
+			"vsport": {
+				"type": "integer",
+				"minimum": 1,
+				"maximum": 65535,
+		        "required": true
+			},
+			"queryport": {
+				"type": "integer",
+				"minimum": 1,
+				"maximum": 65535,
+		        "required": true
+			},
+			"fileport": {
+				"type": "integer",
+				"minimum": 1,
+				"maximum": 65535,
+		        "required": true
+			},
+			"showtab": {
+				"type": "boolean",
+		        "required": true
+			},
+			"languagewi": {
+				"type": "string",
+				"enum": [ "de", "en", "nl", "fr" ],
+		        "required": true
+			},
+			"eula": {
+				"type": "boolean",
+		        "required": true
+			},
+			"update": {
+				"type": "boolean",
+		        "required": true
+			},
+			"restartmsg": {
+				"type": "string",
+		        "required": true
+			}
+		}
+	}
+}]

--- a/usr/share/openmediavault/engined/module/teamspeak3.inc
+++ b/usr/share/openmediavault/engined/module/teamspeak3.inc
@@ -80,25 +80,6 @@ class OMVModuleTeamspeak3 extends \OMV\Engine\Module\ServiceAbstract implements
             "title" => gettext("teamspeak3"),
             "enabled" => $object->get("enable"),
             "running" => $systemCtl->isActive()
-
-        // global $xmlConfig;
-
-        // $object = $xmlConfig->get($this->getXPath());
-
-        // if (is_null($object)) {
-        //     throw new OMVException(
-        //         OMVErrorMsg::E_CONFIG_GET_OBJECT_FAILED,
-        //         $this->getXPath()
-        //     );
-        // }
-
-        // $systemCtl = new OMVSystemCtl($this->getPluginName());
-
-        // return array(
-        //     "name"    => $this->getName(),
-        //     "title"   => gettext("TeamSpeak 3"),
-        //     "enabled" => boolval($object["enable"]),
-        //     "running" => $systemCtl->isActive()
         );
     }
 
@@ -112,35 +93,6 @@ class OMVModuleTeamspeak3 extends \OMV\Engine\Module\ServiceAbstract implements
         // Start this service and enable the unit file.
         $systemCtl = new \OMV\System\SystemCtl("teamspeak3");
         $systemCtl->enable(TRUE);
-
-        // global $xmlConfig;
-
-        // $object = $xmlConfig->get($this->getXPath());
-
-        // if (is_null($object)) {
-        //     throw new OMVException(
-        //         OMVErrorMsg::E_CONFIG_GET_OBJECT_FAILED,
-        //         $this->getXPath()
-        //     );
-        // }
-
-        // if (!boolval($object["enable"])) {
-        //     return;
-        // }
-
-        // // Use below or the $cmd way?
-        // $systemCtl = new OMVSystemCtl($this->getPluginName());
-        // $systemCtl->enable(true);
-
-        // //$cmd = "sudo -u ts3 /etc/init.d/teamspeak3 start && update-rc.d teamspeak3 enable > /dev/null";
-
-        // //if (0 !== $this->exec($cmd, $output)) {
-        // //    throw new OMVException(
-        // //        OMVErrorMsg::E_EXEC_FAILED,
-        // //        $cmd,
-        // //        implode(PHP_EOL, $output)
-        // //    );
-        // //}
     }
 
     public function stopService()
@@ -164,8 +116,6 @@ class OMVModuleTeamspeak3 extends \OMV\Engine\Module\ServiceAbstract implements
 
         $moduleMgr = \OMV\Engine\Module\Manager::getInstance();
 
-        // $moduleMgr = &OMVModuleMgre::getInstance();
-
         $dispatcher->addListener(
             OMV_NOTIFY_MODIFY,
             "org.openmediavault.conf.service.teamspeak3",
@@ -177,30 +127,5 @@ class OMVModuleTeamspeak3 extends \OMV\Engine\Module\ServiceAbstract implements
             "org.openmediavault.conf.service.teamspeak3",
             [ $moduleMgr->getModule("webserver"), "setDirty" ]
         );
-
-        // $moduleMgr = &OMVModuleMgr::getInstance();
-
-        // $dispatcher->addListener(
-        //     OMV_NOTIFY_MODIFY,
-        //     $this->getEventMessagePath(),
-        //     array($this, "setDirty")
-        // );
-
-        // $dispatcher->addListener(
-        //     OMV_NOTIFY_MODIFY,
-        //     $this->getEventMessagePath(),
-        //     array($moduleMgr->getModule("php5fpm"), "setDirty")
-        // );
-
-        // $dispatcher->addListener(
-        //     OMV_NOTIFY_MODIFY,
-        //     $this->getEventMessagePath(),
-        //     array($moduleMgr->getModule("webserver"), "setDirty")
-        // );
     }
 }
-
-// // Register module
-// $moduleMgr = &OMVModuleMgr::getInstance();
-// $moduleMgr->registerModule(new OMVModuleTeamspeak3());
-

--- a/usr/share/openmediavault/engined/module/teamspeak3.inc
+++ b/usr/share/openmediavault/engined/module/teamspeak3.inc
@@ -1,7 +1,10 @@
 <?php
-
 /**
- * Copyright (C) 2013-2014 OpenMediaVault Plugin Developers
+ * @license http://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author Volker Theile <volker.theile@openmediavault.org>
+ * @author OpenMediaVault Plugin Developers <plugins@omvextras.org>
+ * @copyright Copyright (c) 2009-2013 Volker Theile
+ * @copyright Copyright (c) 2013-2017 OpenMediaVault Plugin Developers
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,135 +20,187 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-require_once "openmediavault/config.inc";
-require_once "openmediavault/error.inc";
-require_once "openmediavault/systemctl.inc";
-require_once "openmediavault/module.inc";
-require_once "openmediavault/util.inc";
+// require_once "openmediavault/config.inc";
+// require_once "openmediavault/error.inc";
+// require_once "openmediavault/systemctl.inc";
+// require_once "openmediavault/module.inc";
+// require_once "openmediavault/util.inc";
 
-class OMVModuleTeamspeak3 extends OMVModuleServiceAbstract implements
-    OMVINotifyListener,
-    OMVIModuleServiceStatus
+// class OMVModuleTeamspeak3 extends OMVModuleServiceAbstract implements
+//     OMVINotifyListener,
+//     OMVIModuleServiceStatus
+class OMVModuleTeamspeak3 extends \OMV\Engine\Module\ServiceAbstract implements
+    \OMV\Engine\Notify\IListener, \OMV\Engine\Module\IServiceStatus
 {
-    private function getPluginName()
-    {
-        return strtolower($this->getName());
-    }
+    // private function getPluginName()
+    // {
+    //     return strtolower($this->getName());
+    // }
 
-    private function getEventMessagePath()
-    {
-        return sprintf("org.openmediavault.service.%s", $this->getPluginName());
-    }
+    // private function getEventMessagePath()
+    // {
+    //     return sprintf("org.openmediavault.service.%s", $this->getPluginName());
+    // }
 
-    private function getXPath()
-    {
-        return sprintf(" /config/services/%s", $this->getPluginName());
-    }
+    // private function getXPath()
+    // {
+    //     return sprintf(" /config/services/%s", $this->getPluginName());
+    // }
 
     public function getName()
     {
-        return "teamspeak3";
+        return "Teamspeak3";
     }
 
     public function applyConfig()
     {
-        $cmd = sprintf("omv-mkconf %s firstrun 2>&1", $this->getPluginName());
+        $cmd = new \OMV\System\Process("omv-mkconf", "teamspeak3", "firstrun");
+        $cmd->setRedirect2to1();
+        $cmd->execute();
 
-        if (0 !== $this->exec($cmd, $output)) {
-            throw new OMVException(
-                OMVErrorMsg::E_EXEC_FAILED,
-                $cmd,
-                implode(PHP_EOL, $output)
-            );
-        }
+
+        // $cmd = sprintf("omv-mkconf %s firstrun 2>&1", $this->getPluginName());
+
+        // if (0 !== $this->exec($cmd, $output)) {
+        //     throw new OMVException(
+        //         OMVErrorMsg::E_EXEC_FAILED,
+        //         $cmd,
+        //         implode(PHP_EOL, $output)
+        //     );
+        // }
     }
 
     public function getStatus()
     {
-        global $xmlConfig;
-
-        $object = $xmlConfig->get($this->getXPath());
-
-        if (is_null($object)) {
-            throw new OMVException(
-                OMVErrorMsg::E_CONFIG_GET_OBJECT_FAILED,
-                $this->getXPath()
-            );
-        }
-
-        $systemCtl = new OMVSystemCtl($this->getPluginName());
-
+        $db = \OMV\Config\Database::getInstance();
+        $object = $db->get("conf.service.teamspeak3");
+        $systemCtl = new \OMV\System\SystemCtl("teamspeak3");
         return array(
-            "name"    => $this->getName(),
-            "title"   => gettext("TeamSpeak 3"),
-            "enabled" => boolval($object["enable"]),
+            "name" => $this->getName(),
+            "title" => gettext("teamspeak3"),
+            "enabled" => $object->get("enable"),
             "running" => $systemCtl->isActive()
+
+        // global $xmlConfig;
+
+        // $object = $xmlConfig->get($this->getXPath());
+
+        // if (is_null($object)) {
+        //     throw new OMVException(
+        //         OMVErrorMsg::E_CONFIG_GET_OBJECT_FAILED,
+        //         $this->getXPath()
+        //     );
+        // }
+
+        // $systemCtl = new OMVSystemCtl($this->getPluginName());
+
+        // return array(
+        //     "name"    => $this->getName(),
+        //     "title"   => gettext("TeamSpeak 3"),
+        //     "enabled" => boolval($object["enable"]),
+        //     "running" => $systemCtl->isActive()
         );
     }
 
     public function startService()
     {
-        global $xmlConfig;
-
-        $object = $xmlConfig->get($this->getXPath());
-
-        if (is_null($object)) {
-            throw new OMVException(
-                OMVErrorMsg::E_CONFIG_GET_OBJECT_FAILED,
-                $this->getXPath()
-            );
-        }
-
-        if (!boolval($object["enable"])) {
+        // Check to see if plugin is enabled
+        $db = \OMV\Config\Database::getInstance();
+        $object = $db->get("conf.service.teamspeak3");
+        if (TRUE !== $object->get("enable"))
             return;
-        }
+        // Start this service and enable the unit file.
+        $systemCtl = new \OMV\System\SystemCtl("teamspeak3");
+        $systemCtl->enable(TRUE);
 
-        // Use below or the $cmd way?
-        $systemCtl = new OMVSystemCtl($this->getPluginName());
-        $systemCtl->enable(true);
+        // global $xmlConfig;
 
-        //$cmd = "sudo -u ts3 /etc/init.d/teamspeak3 start && update-rc.d teamspeak3 enable > /dev/null";
+        // $object = $xmlConfig->get($this->getXPath());
 
-        //if (0 !== $this->exec($cmd, $output)) {
-        //    throw new OMVException(
-        //        OMVErrorMsg::E_EXEC_FAILED,
-        //        $cmd,
-        //        implode(PHP_EOL, $output)
-        //    );
-        //}
+        // if (is_null($object)) {
+        //     throw new OMVException(
+        //         OMVErrorMsg::E_CONFIG_GET_OBJECT_FAILED,
+        //         $this->getXPath()
+        //     );
+        // }
+
+        // if (!boolval($object["enable"])) {
+        //     return;
+        // }
+
+        // // Use below or the $cmd way?
+        // $systemCtl = new OMVSystemCtl($this->getPluginName());
+        // $systemCtl->enable(true);
+
+        // //$cmd = "sudo -u ts3 /etc/init.d/teamspeak3 start && update-rc.d teamspeak3 enable > /dev/null";
+
+        // //if (0 !== $this->exec($cmd, $output)) {
+        // //    throw new OMVException(
+        // //        OMVErrorMsg::E_EXEC_FAILED,
+        // //        $cmd,
+        // //        implode(PHP_EOL, $output)
+        // //    );
+        // //}
     }
 
     public function stopService()
     {
-        $systemCtl = new OMVSystemCtl($this->getPluginName());
-        $systemCtl->disable(true);
+        $systemCtl = new \OMV\System\SystemCtl("teamspeak3");
+        $systemCtl->disable(TRUE);
+        // $systemCtl = new OMVSystemCtl($this->getPluginName());
+        // $systemCtl->disable(true);
     }
 
-    public function bindListeners(OMVNotifyDispatcher $dispatcher)
+    public function bindListeners(\OMV\Engine\Notify\Dispatcher $dispatcher)
+    // public function bindListeners(OMVNotifyDispatcher $dispatcher)
     {
-        $moduleMgr = &OMVModuleMgr::getInstance();
+        // This will notify OMV of changes for each configuration type 
+        // and the level to notify.
+        $dispatcher->addListener(
+            OMV_NOTIFY_MODIFY,
+            "org.openmediavault.conf.service.teamspeak3",
+            [ $this, "setDirty" ]
+        );
+
+        $moduleMgr = \OMV\Engine\Module\Manager::getInstance();
+
+        // $moduleMgr = &OMVModuleMgre::getInstance();
 
         $dispatcher->addListener(
             OMV_NOTIFY_MODIFY,
-            $this->getEventMessagePath(),
-            array($this, "setDirty")
+            "org.openmediavault.conf.service.teamspeak3",
+            [ $moduleMgr->getModule("php5fpm"), "setDirty" ]
         );
 
         $dispatcher->addListener(
             OMV_NOTIFY_MODIFY,
-            $this->getEventMessagePath(),
-            array($moduleMgr->getModule("php5fpm"), "setDirty")
+            "org.openmediavault.conf.service.teamspeak3",
+            [ $moduleMgr->getModule("webserver"), "setDirty" ]
         );
 
-        $dispatcher->addListener(
-            OMV_NOTIFY_MODIFY,
-            $this->getEventMessagePath(),
-            array($moduleMgr->getModule("webserver"), "setDirty")
-        );
+        // $moduleMgr = &OMVModuleMgr::getInstance();
+
+        // $dispatcher->addListener(
+        //     OMV_NOTIFY_MODIFY,
+        //     $this->getEventMessagePath(),
+        //     array($this, "setDirty")
+        // );
+
+        // $dispatcher->addListener(
+        //     OMV_NOTIFY_MODIFY,
+        //     $this->getEventMessagePath(),
+        //     array($moduleMgr->getModule("php5fpm"), "setDirty")
+        // );
+
+        // $dispatcher->addListener(
+        //     OMV_NOTIFY_MODIFY,
+        //     $this->getEventMessagePath(),
+        //     array($moduleMgr->getModule("webserver"), "setDirty")
+        // );
     }
 }
 
-// Register module
-$moduleMgr = &OMVModuleMgr::getInstance();
-$moduleMgr->registerModule(new OMVModuleTeamspeak3());
+// // Register module
+// $moduleMgr = &OMVModuleMgr::getInstance();
+// $moduleMgr->registerModule(new OMVModuleTeamspeak3());
 

--- a/usr/share/openmediavault/engined/module/teamspeak3.inc
+++ b/usr/share/openmediavault/engined/module/teamspeak3.inc
@@ -26,27 +26,9 @@
 // require_once "openmediavault/module.inc";
 // require_once "openmediavault/util.inc";
 
-// class OMVModuleTeamspeak3 extends OMVModuleServiceAbstract implements
-//     OMVINotifyListener,
-//     OMVIModuleServiceStatus
 class OMVModuleTeamspeak3 extends \OMV\Engine\Module\ServiceAbstract implements
     \OMV\Engine\Notify\IListener, \OMV\Engine\Module\IServiceStatus
 {
-    // private function getPluginName()
-    // {
-    //     return strtolower($this->getName());
-    // }
-
-    // private function getEventMessagePath()
-    // {
-    //     return sprintf("org.openmediavault.service.%s", $this->getPluginName());
-    // }
-
-    // private function getXPath()
-    // {
-    //     return sprintf(" /config/services/%s", $this->getPluginName());
-    // }
-
     public function getName()
     {
         return "Teamspeak3";
@@ -57,17 +39,6 @@ class OMVModuleTeamspeak3 extends \OMV\Engine\Module\ServiceAbstract implements
         $cmd = new \OMV\System\Process("omv-mkconf", "teamspeak3", "firstrun");
         $cmd->setRedirect2to1();
         $cmd->execute();
-
-
-        // $cmd = sprintf("omv-mkconf %s firstrun 2>&1", $this->getPluginName());
-
-        // if (0 !== $this->exec($cmd, $output)) {
-        //     throw new OMVException(
-        //         OMVErrorMsg::E_EXEC_FAILED,
-        //         $cmd,
-        //         implode(PHP_EOL, $output)
-        //     );
-        // }
     }
 
     public function getStatus()
@@ -99,8 +70,6 @@ class OMVModuleTeamspeak3 extends \OMV\Engine\Module\ServiceAbstract implements
     {
         $systemCtl = new \OMV\System\SystemCtl("teamspeak3");
         $systemCtl->disable(TRUE);
-        // $systemCtl = new OMVSystemCtl($this->getPluginName());
-        // $systemCtl->disable(true);
     }
 
     public function bindListeners(\OMV\Engine\Notify\Dispatcher $dispatcher)

--- a/usr/share/openmediavault/engined/rpc/teamspeak3.inc
+++ b/usr/share/openmediavault/engined/rpc/teamspeak3.inc
@@ -22,21 +22,6 @@
 
 class OMVRpcServiceTeamspeak3 extends \OMV\Rpc\ServiceAbstract
 {
-    // private function getPluginName()
-    // {
-    //     return strtolower($this->getName());
-    // }
-
-    // private function getEventMessagePath()
-    // {
-    //     return sprintf("org.openmediavault.service.%s", $this->getPluginName());
-    // }
-
-    // private function getXPath()
-    // {
-    //     return sprintf(" /config/services/%s", $this->getPluginName());
-    // }
-
     public function getName()
     {
         return "Teamspeak3";
@@ -90,15 +75,6 @@ class OMVRpcServiceTeamspeak3 extends \OMV\Rpc\ServiceAbstract
         $cmd = new \OMV\System\Process("omv-mkconf", "teamspeak3", "update");
         $cmd->setRedirect2to1();
         $cmd->execute();
-        // $cmd = sprintf("omv-mkconf %s update 2>&1", $this->getPluginName());
-
-        // if (0 !== $this->exec($cmd, $output)) {
-        //     throw new OMVException(
-        //         OMVErrorMsg::E_EXEC_FAILED,
-        //         $cmd,
-        //         implode(PHP_EOL, $output)
-        //     );
-        // }
 
         $dispatcher = \OMV\Engine\Notify\Dispatcher::getInstance();
         $dispatcher->notify(
@@ -106,13 +82,6 @@ class OMVRpcServiceTeamspeak3 extends \OMV\Rpc\ServiceAbstract
             'conf.services.teamspeak3',
             $object->getAssoc()
         );
-
-        // $dispatcher = &OMVNotifyDispatcher::getInstance();
-        // $dispatcher->notify(
-        //     OMV_NOTIFY_MODIFY,
-        //     $this->getEventMessagePath(),
-        //     $object
-        // );
     }
 
     public function doUpdateEULA($params, $context) 
@@ -120,20 +89,5 @@ class OMVRpcServiceTeamspeak3 extends \OMV\Rpc\ServiceAbstract
         $cmd = new \OMV\System\Process("omv-mkconf", "teamspeak3", "eula");
         $cmd->setRedirect2to1();
         $cmd->execute();
-        // $cmd->execute($output);
-
-        // $cmd = sprintf("omv-mkconf %s eula 2>&1", $this->getPluginName());
-
-        // if (0 !== $output) {
-        //     throw new OMVException(
-        //         OMVErrorMsg::E_EXEC_FAILED,
-        //         $cmd,
-        //         implode(PHP_EOL, $output)
-        //     );
-        // }
     }
 }
-
-// // Register the RPC service.
-// $rpcServiceMgr = &OMVRpcServiceMgr::getInstance();
-// $rpcServiceMgr->registerService(new OMVRpcServiceTeamspeak3());

--- a/usr/share/openmediavault/engined/rpc/teamspeak3.inc
+++ b/usr/share/openmediavault/engined/rpc/teamspeak3.inc
@@ -1,7 +1,10 @@
 <?php
-
 /**
- * Copyright (C) 2013-2014 OpenMediaVault Plugin Developers
+ * @license http://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author Volker Theile <volker.theile@openmediavault.org>
+ * @author OpenMediaVault Plugin Developers <plugins@omvextras.org>
+ * @copyright Copyright (c) 2009-2013 Volker Theile
+ * @copyright Copyright (c) 2013-2017 OpenMediaVault Plugin Developers
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,31 +20,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-require_once "openmediavault/config.inc";
-require_once "openmediavault/error.inc";
-require_once "openmediavault/notify.inc";
-require_once "openmediavault/object.inc";
-require_once "openmediavault/product.inc";
-require_once "openmediavault/rpcservice.inc";
-require_once "openmediavault/system.inc";
-require_once "openmediavault/util.inc";
-
-class OMVRpcServiceTeamspeak3 extends OMVRpcServiceAbstract
+class OMVRpcServiceTeamspeak3 extends \OMV\Rpc\ServiceAbstract
 {
-    private function getPluginName()
-    {
-        return strtolower($this->getName());
-    }
+    // private function getPluginName()
+    // {
+    //     return strtolower($this->getName());
+    // }
 
-    private function getEventMessagePath()
-    {
-        return sprintf("org.openmediavault.service.%s", $this->getPluginName());
-    }
+    // private function getEventMessagePath()
+    // {
+    //     return sprintf("org.openmediavault.service.%s", $this->getPluginName());
+    // }
 
-    private function getXPath()
-    {
-        return sprintf(" /config/services/%s", $this->getPluginName());
-    }
+    // private function getXPath()
+    // {
+    //     return sprintf(" /config/services/%s", $this->getPluginName());
+    // }
 
     public function getName()
     {
@@ -58,137 +52,88 @@ class OMVRpcServiceTeamspeak3 extends OMVRpcServiceAbstract
 
     public function getSettings($params, $context)
     {
-        $this->exec("omv-mkconf "
-             . $this->getPluginName()
-             . " getsettings 2>&1");
-        
-        global $xmlConfig;
+        // Validate the RPC caller context. 
+        $this->validateMethodContext($context, ["role" => OMV_ROLE_ADMINISTRATOR]);
+        // Get the configuration object.
+        $db = \OMV\Config\Database::getInstance();
+        $object = $db->get("conf.service.teamspeak3");
 
-        $this->validateMethodContext($context, array(
-            "role" => OMV_ROLE_ADMINISTRATOR
-        ));
-
-        $object = $xmlConfig->get($this->getXPath());
-
-        if (is_null($object)) {
-            throw new OMVException(
-                OMVErrorMsg::E_CONFIG_GET_OBJECT_FAILED,
-                $this->getXPath()
-            );
-        }
-
-        $object["enable"]	= boolval($object["enable"]);
-        $object["showtab"]	= boolval($object["showtab"]);
-        $object["update"]	= boolval($object["update"]);
-        $object["enablewi"] = boolval($object["enablewi"]);
-
-        return $object;
+        // Return the configuration object.
+        return $object->getAssoc();
     }
 
     public function setSettings($params, $context)
     {
-        global $xmlConfig;
-
-        $this->validateMethodContext($context, array(
-            "role" => OMV_ROLE_ADMINISTRATOR
-        ));
-
-        $this->validateMethodParams(
-            $params,
-            '{
-                "type"       : "object",
-                "properties" : {
-                    "enable"     : { "type" : "boolean" },
-                    "showtab"    : { "type" : "boolean" },
-                    "update"     : { "type" : "boolean" },
-                    "password"   : { "type" : "string" },
-                    "queryport"  : { "type" : "integer","minimum":1,"maximum":65535 },
-                    "vsport"     : { "type" : "integer","minimum":1,"maximum":65535 },
-                    "fileport"   : { "type" : "integer","minimum":1,"maximum":65535 },
-                    "restartmsg" : { "type" : "string" },
-                    "eula"       : { "type" : "boolean" },
-                    "enablewi"   : { "type" : "boolean" },
-                    "languagewi" : { "type" : "string" }
-
-                }
-            }'
-        );
-
-
+        // Validate the RPC caller context.
+        $this->validateMethodContext($context, ["role" => OMV_ROLE_ADMINISTRATOR]);
+        // Validate the parameters of the RPC service method.
+        $this->validateMethodParams($params, "rpc.teamspeak3.setsettings");
         // Get existing configuration object
-        $oldObject = $xmlConfig->get($this->getXPath());
+        $db = \OMV\Config\Database::getInstance();
+        $object = $db->get("conf.service.teamspeak3");
+        $object->setAssoc($params); 
+        $db->set($object);
 
-        if (is_null($oldObject)) {
-            throw new OMVException(
-                OMVErrorMsg::E_CONFIG_GET_OBJECT_FAILED,
-                $this->getXPath()
-            );
-        }
-
-        $object = array(
-            "enable"      => array_boolval($params, "enable"),
-            "showtab"     => array_boolval($params, "showtab"),
-            "update"      => array_boolval($params, "update"),
-            "password"    => $params["password"],
-            "queryport"   => $params["queryport"],
-            "vsport"      => $params["vsport"],
-            "fileport"    => $params["fileport"],
-            "restartmsg"  => $params["restartmsg"],
-            "eula"        => array_boolval($params, "eula"),
-            "enablewi"    => array_boolval($params, "enablewi"),
-            "langquagewi" => $params["languagewi"],
-        );
-
-        if (false === $xmlConfig->replace($this->getXPath(), $object)) {
-            throw new OMVException(
-                OMVErrorMsg::E_CONFIG_SET_OBJECT_FAILED,
-                $this->getXPath()
-            );
-        }
-
-        $dispatcher = &OMVNotifyDispatcher::getInstance();
+        $dispatcher = \OMV\Engine\Notify\Dispatcher::getInstance();
         $dispatcher->notify(
             OMV_NOTIFY_MODIFY,
-            $this->getEventMessagePath(),
-            $object
+            'conf.services.teamspeak3',
+            $object->getAssoc()
         );
 
-        return $object;
+        // Return the configuration object.
+        return $object->getAssoc();
     }
 
     public function doUpdateTS3($params, $context)
     {
-        $cmd = sprintf("omv-mkconf %s update 2>&1", $this->getPluginName());
+        $cmd = new \OMV\System\Process("omv-mkconf", "teamspeak3", "update");
+        $cmd->setRedirect2to1();
+        $cmd->execute();
+        // $cmd = sprintf("omv-mkconf %s update 2>&1", $this->getPluginName());
 
-        if (0 !== $this->exec($cmd, $output)) {
-            throw new OMVException(
-                OMVErrorMsg::E_EXEC_FAILED,
-                $cmd,
-                implode(PHP_EOL, $output)
-            );
-        }
+        // if (0 !== $this->exec($cmd, $output)) {
+        //     throw new OMVException(
+        //         OMVErrorMsg::E_EXEC_FAILED,
+        //         $cmd,
+        //         implode(PHP_EOL, $output)
+        //     );
+        // }
 
-        $dispatcher = &OMVNotifyDispatcher::getInstance();
+        $dispatcher = \OMV\Engine\Notify\Dispatcher::getInstance();
         $dispatcher->notify(
             OMV_NOTIFY_MODIFY,
-            $this->getEventMessagePath(),
-            $object
+            'conf.services.teamspeak3',
+            $object->getAssoc()
         );
+
+        // $dispatcher = &OMVNotifyDispatcher::getInstance();
+        // $dispatcher->notify(
+        //     OMV_NOTIFY_MODIFY,
+        //     $this->getEventMessagePath(),
+        //     $object
+        // );
     }
 
-    public function doUpdateEULA($params, $context) {
-        $cmd = sprintf("omv-mkconf %s eula 2>&1", $this->getPluginName());
+    public function doUpdateEULA($params, $context) 
+    {
+        $cmd = new \OMV\System\Process("omv-mkconf", "teamspeak3", "eula");
+        $cmd->setRedirect2to1();
+        $cmd->execute();
+        // $cmd->execute($output);
 
-        if (0 !== $this->exec($cmd, $output)) {
-            throw new OMVException(
-                OMVErrorMsg::E_EXEC_FAILED,
-                $cmd,
-                implode(PHP_EOL, $output)
-            );
-        }
+        // $cmd = sprintf("omv-mkconf %s eula 2>&1", $this->getPluginName());
+
+        // if (0 !== $output) {
+        //     throw new OMVException(
+        //         OMVErrorMsg::E_EXEC_FAILED,
+        //         $cmd,
+        //         implode(PHP_EOL, $output)
+        //     );
+        // }
     }
 }
 
-// Register the RPC service.
-$rpcServiceMgr = &OMVRpcServiceMgr::getInstance();
-$rpcServiceMgr->registerService(new OMVRpcServiceTeamspeak3());
+// // Register the RPC service.
+// $rpcServiceMgr = &OMVRpcServiceMgr::getInstance();
+// $rpcServiceMgr->registerService(new OMVRpcServiceTeamspeak3());

--- a/usr/share/openmediavault/mkconf/teamspeak3
+++ b/usr/share/openmediavault/mkconf/teamspeak3
@@ -1,4 +1,23 @@
 #!/bin/bash
+#
+# @license http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author Volker Theile <volker.theile@openmediavault.org>
+# @author OpenMediaVault Plugin Developers <plugins@omvextras.org>
+# @copyright Copyright (c) 2009-2013 Volker Theile
+# @copyright Copyright (c) 2013-2017 OpenMediaVault Plugin Developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 set -e
 
@@ -13,8 +32,9 @@ options="createinifile=1"
 TEAMSPEAK3_INI="/opt/teamspeak3/ts3server.ini"
 TS3WI_CONFIG="/usr/share/ts3wi/config.php"
 
-if [ ! "$2" == "getsettings" ] || [ ! "$2" == "update" ]; then
+if [ ! "$1" == "getsettings" ] || [ ! "$1" == "update" ]; then
 	if [ -d $APP_PATH ]; then
+		echo "if"
 		cat /dev/null > ${TEAMSPEAK3_INI}
 			xmlstarlet sel -t -m " /config/services/teamspeak3" \
 			-o "machine_id=" -n \
@@ -82,7 +102,9 @@ fi
 
 get_info() {
 	# Fetch latest version from www.teamspeak.com
-	LATEST_VERSION=`curl -s -L http://www.teamspeak.com/downloads#server | grep -A 6 'Server 64-bit' | head -n 2 | grep -Po '(?<=version">)[^<]+'`
+	# changed to be more flexible with page layout
+	# the version need to be in the form \d+\.
+	LATEST_VERSION=`curl -s -L http://www.teamspeak.com/downloads#server | grep -A 3 'Server 64-bit' | grep -P '\d\.' | awk 'NR==1 {print $1 }'`
 	if arch | grep x86_64 >/dev/null 2>&1; then
 		ARCHITECTURE="amd64"
 	else
@@ -104,6 +126,7 @@ dl_ts3() {
 }
 
 first_run() {
+	echo "firstrun"
 	if [ ! -d "$APP_PATH" ]; then
 		if [ $(omv_config_get ' /config/services/teamspeak3/enable') != "1" ]; then
 			exit 0
@@ -275,7 +298,7 @@ getsettings() {
 	fi
 }
 
-case "$2" in
+case "$1" in
   update)
 	update
 	;;

--- a/var/www/openmediavault/js/omv/module/admin/service/teamspeak3/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/teamspeak3/Settings.js
@@ -1,5 +1,9 @@
 /**
- * Copyright (C) 2013-2015 OpenMediaVault Plugin Developers
+ * @license http://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author Volker Theile <volker.theile@openmediavault.org>
+ * @author OpenMediaVault Plugin Developers <plugins@omvextras.org>
+ * @copyright Copyright (c) 2009-2013 Volker Theile
+ * @copyright Copyright (c) 2013-2017 OpenMediaVault Plugin Developers
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/var/www/openmediavault/js/omv/module/admin/service/teamspeak3/Teamspeak3.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/teamspeak3/Teamspeak3.js
@@ -1,5 +1,9 @@
 /**
- * Copyright (C) 2013-2014 OpenMediaVault Plugin Developers
+ * @license http://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author Volker Theile <volker.theile@openmediavault.org>
+ * @author OpenMediaVault Plugin Developers <plugins@omvextras.org>
+ * @copyright Copyright (c) 2009-2013 Volker Theile
+ * @copyright Copyright (c) 2013-2017 OpenMediaVault Plugin Developers
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/var/www/openmediavault/js/omv/module/admin/service/teamspeak3/WebInterface.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/teamspeak3/WebInterface.js
@@ -1,5 +1,9 @@
 /**
- * Copyright (C) 2013-2014 OpenMediaVault Plugin Developers
+ * @license http://www.gnu.org/licenses/gpl.html GPL Version 3
+ * @author Volker Theile <volker.theile@openmediavault.org>
+ * @author OpenMediaVault Plugin Developers <plugins@omvextras.org>
+ * @copyright Copyright (c) 2009-2013 Volker Theile
+ * @copyright Copyright (c) 2013-2017 OpenMediaVault Plugin Developers
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Update for OMV >=3.0.15

- added datamodels
- fix error getting Teamspeak version
- fix $2 to $1 for calls to omv-mkconf
- fix RPC and module files to ensure compatibility with version (<-- my be incomplete)

version is UNSTABLE:
main bug still is that the web ui ts3ui is not working, not mean to get the master key has been implemented
the service teamspeak3 is working
webui "Update Teamspeak" is not visible (<-- normal ?)